### PR TITLE
Handle missing packages for FFT baked collisions

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderBakedFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderBakedFFT.cs
@@ -2,6 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+#if CREST_MATH
+
 using System.Collections.Generic;
 using Unity.Burst;
 using Unity.Collections;
@@ -385,7 +387,9 @@ namespace Crest
         /// <summary>
         /// Job to compute height queries
         /// </summary>
+#if CREST_BURST
         [BurstCompile(CompileSynchronously = true)]
+#endif
         private struct JobSampleHeight : IJobParallelFor
         {
             [ReadOnly]
@@ -419,7 +423,9 @@ namespace Crest
         /// <summary>
         /// Job to compute displacement
         /// </summary>
+#if CREST_BURST
         [BurstCompile(CompileSynchronously = true)]
+#endif
         private struct JobSampleDisplacement : IJobParallelFor
         {
             [ReadOnly]
@@ -459,7 +465,9 @@ namespace Crest
         /// <summary>
         /// Job to compute surface normal queries
         /// </summary>
+#if CREST_BURST
         [BurstCompile(CompileSynchronously = true)]
+#endif
         private struct JobComputeNormal : IJobParallelFor
         {
             [ReadOnly]
@@ -508,7 +516,9 @@ namespace Crest
         /// <summary>
         /// Job to compute surface velocity. Currently vertical only, this could likely be extended to return full 3D velocity.
         /// </summary>
+#if CREST_BURST
         [BurstCompile(CompileSynchronously = true)]
+#endif
         private struct JobComputeVerticalVelocity : IJobParallelFor
         {
             [ReadOnly]
@@ -597,3 +607,5 @@ namespace Crest
         }
     }
 }
+
+#endif // CREST_MATH

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderBakedFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderBakedFFT.cs
@@ -2,7 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
 
 using System.Collections.Generic;
 using Unity.Burst;
@@ -387,7 +387,7 @@ namespace Crest
         /// <summary>
         /// Job to compute height queries
         /// </summary>
-#if CREST_BURST
+#if CREST_UNITY_BURST
         [BurstCompile(CompileSynchronously = true)]
 #endif
         private struct JobSampleHeight : IJobParallelFor
@@ -423,7 +423,7 @@ namespace Crest
         /// <summary>
         /// Job to compute displacement
         /// </summary>
-#if CREST_BURST
+#if CREST_UNITY_BURST
         [BurstCompile(CompileSynchronously = true)]
 #endif
         private struct JobSampleDisplacement : IJobParallelFor
@@ -465,7 +465,7 @@ namespace Crest
         /// <summary>
         /// Job to compute surface normal queries
         /// </summary>
-#if CREST_BURST
+#if CREST_UNITY_BURST
         [BurstCompile(CompileSynchronously = true)]
 #endif
         private struct JobComputeNormal : IJobParallelFor
@@ -516,7 +516,7 @@ namespace Crest
         /// <summary>
         /// Job to compute surface velocity. Currently vertical only, this could likely be extended to return full 3D velocity.
         /// </summary>
-#if CREST_BURST
+#if CREST_UNITY_BURST
         [BurstCompile(CompileSynchronously = true)]
 #endif
         private struct JobComputeVerticalVelocity : IJobParallelFor
@@ -608,4 +608,4 @@ namespace Crest
     }
 }
 
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS

--- a/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
@@ -29,6 +29,16 @@
             "name": "com.unity.modules.xr",
             "expression": "1.0.0",
             "define": "ENABLE_XR_MODULE"
+        },
+        {
+            "name": "com.unity.burst",
+            "expression": "1.0.0",
+            "define": "CREST_BURST"
+        },
+        {
+            "name": "com.unity.mathematics",
+            "expression": "1.0.0",
+            "define": "CREST_MATH"
         }
     ],
     "noEngineReferences": false

--- a/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
@@ -33,12 +33,12 @@
         {
             "name": "com.unity.burst",
             "expression": "1.0.0",
-            "define": "CREST_BURST"
+            "define": "CREST_UNITY_BURST"
         },
         {
             "name": "com.unity.mathematics",
             "expression": "1.0.0",
-            "define": "CREST_MATH"
+            "define": "CREST_UNITY_MATHEMATICS"
         }
     ],
     "noEngineReferences": false

--- a/crest/Assets/Crest/Crest/Scripts/Editor/Crest.Editor.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/Crest.Editor.asmdef
@@ -14,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.mathematics",
+            "expression": "1.0.0",
+            "define": "CREST_MATH"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/crest/Assets/Crest/Crest/Scripts/Editor/Crest.Editor.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/Crest.Editor.asmdef
@@ -18,7 +18,7 @@
         {
             "name": "com.unity.mathematics",
             "expression": "1.0.0",
-            "define": "CREST_MATH"
+            "define": "CREST_UNITY_MATHEMATICS"
         }
     ],
     "noEngineReferences": false

--- a/crest/Assets/Crest/Crest/Scripts/Editor/SimSettingsAnimatedWavesPreview.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/SimSettingsAnimatedWavesPreview.cs
@@ -2,6 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+#if CREST_MATH
+
 using Unity.Collections;
 using UnityEditor;
 using UnityEngine;
@@ -108,3 +110,5 @@ namespace Crest
         }
     }
 }
+
+#endif // CREST_MATH

--- a/crest/Assets/Crest/Crest/Scripts/Editor/SimSettingsAnimatedWavesPreview.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/SimSettingsAnimatedWavesPreview.cs
@@ -2,7 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
 
 using Unity.Collections;
 using UnityEditor;
@@ -111,4 +111,4 @@ namespace Crest
     }
 }
 
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/PackageManagerHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/PackageManagerHelpers.cs
@@ -1,0 +1,41 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Helpers for using the Unity Package Manager.
+
+namespace Crest.EditorHelpers
+{
+    using UnityEditor;
+    using UnityEditor.PackageManager;
+    using UnityEditor.PackageManager.Requests;
+    using UnityEngine;
+
+    public static class PackageManagerHelpers
+    {
+        static AddRequest Request;
+
+        public static void AddMissingPackage(string packageName)
+        {
+            Request = Client.Add(packageName);
+            EditorApplication.update += AddMissingPackageProgress;
+        }
+
+        static void AddMissingPackageProgress()
+        {
+            if (Request.IsCompleted)
+            {
+                if (Request.Status == StatusCode.Success)
+                {
+                    Debug.Log("Installed: " + Request.Result.packageId);
+                }
+                else if (Request.Status >= StatusCode.Failure)
+                {
+                    Debug.Log(Request.Error.message);
+                }
+
+                EditorApplication.update -= AddMissingPackageProgress;
+            }
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/PackageManagerHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/PackageManagerHelpers.cs
@@ -13,25 +13,26 @@ namespace Crest.EditorHelpers
 
     public static class PackageManagerHelpers
     {
-        static AddRequest Request;
+        static AddRequest s_Request;
+        public static bool IsBusy => s_Request?.IsCompleted == false;
 
         public static void AddMissingPackage(string packageName)
         {
-            Request = Client.Add(packageName);
+            s_Request = Client.Add(packageName);
             EditorApplication.update += AddMissingPackageProgress;
         }
 
         static void AddMissingPackageProgress()
         {
-            if (Request.IsCompleted)
+            if (s_Request.IsCompleted)
             {
-                if (Request.Status == StatusCode.Success)
+                if (s_Request.Status == StatusCode.Success)
                 {
-                    Debug.Log("Installed: " + Request.Result.packageId);
+                    Debug.Log("Installed: " + s_Request.Result.packageId);
                 }
-                else if (Request.Status >= StatusCode.Failure)
+                else if (s_Request.Status >= StatusCode.Failure)
                 {
-                    Debug.Log(Request.Error.message);
+                    Debug.Log(s_Request.Error.message);
                 }
 
                 EditorApplication.update -= AddMissingPackageProgress;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/PackageManagerHelpers.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/PackageManagerHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68cecf4425feb4d35aefcd2584985ddf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -147,9 +147,9 @@ namespace Crest
                     FixSetCollisionSourceToCompute
                 );
             }
-#if CREST_MATH
             else if (_collisionSource == CollisionSources.BakedFFT)
             {
+#if CREST_MATH
                 if (_bakedFFTData != null)
                 {
                     if (!Mathf.Approximately(_bakedFFTData._parameters._windSpeed * 3.6f, ocean._globalWindSpeed))
@@ -163,8 +163,18 @@ namespace Crest
                         );
                     }
                 }
+#else // CREST_MATH
+                showMessage
+                (
+                    "The <i>Unity Mathematics (com.unity.mathematics)</i> package is required for baked collisions.",
+                    "Add the <i>Unity Mathematics</i> package.",
+                    ValidatedHelper.MessageType.Error, this,
+                    ValidatedHelper.FixAddMissingMathPackage
+                );
+
+                isValid = false;
+#endif // CREST_MATH
             }
-#endif
 
             return isValid;
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -178,7 +178,7 @@ namespace Crest
 #if !CREST_BURST
                 showMessage
                 (
-                    "The <i>Unity Burst (com.unity.mathematics)</i> package will greatly improve performance",
+                    "The <i>Unity Burst (com.unity.burst)</i> package will greatly improve performance.",
                     "Add the <i>Unity Burst</i> package.",
                     ValidatedHelper.MessageType.Warning, this,
                     ValidatedHelper.FixAddMissingBurstPackage

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -174,6 +174,16 @@ namespace Crest
 
                 isValid = false;
 #endif // CREST_MATH
+
+#if !CREST_BURST
+                showMessage
+                (
+                    "The <i>Unity Burst (com.unity.mathematics)</i> package will greatly improve performance",
+                    "Add the <i>Unity Burst</i> package.",
+                    ValidatedHelper.MessageType.Warning, this,
+                    ValidatedHelper.FixAddMissingBurstPackage
+                );
+#endif // CREST_BURST
             }
 
             return isValid;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -51,8 +51,10 @@ namespace Crest
         [Tooltip("The render texture format to use for the wave simulation. It should only be changed if you need more precision. See the documentation for information.")]
         public GraphicsFormat _renderTextureGraphicsFormat = GraphicsFormat.R16G16B16A16_SFloat;
 
+#if CREST_MATH
         [Predicated("_collisionSource", true, (int)CollisionSources.BakedFFT), DecoratedField]
         public FFTBakedData _bakedFFTData;
+#endif // CREST_MATH
 
         public override void AddToSettingsHash(ref int settingsHash)
         {
@@ -86,9 +88,11 @@ namespace Crest
                         Debug.LogError("Crest: Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
                     }
                     break;
+#if CREST_MATH
                 case CollisionSources.BakedFFT:
                     result = new CollProviderBakedFFT(_bakedFFTData);
                     break;
+#endif // CREST_MATH
             }
 
             if (result == null)
@@ -143,6 +147,7 @@ namespace Crest
                     FixSetCollisionSourceToCompute
                 );
             }
+#if CREST_MATH
             else if (_collisionSource == CollisionSources.BakedFFT)
             {
                 if (_bakedFFTData != null)
@@ -159,6 +164,7 @@ namespace Crest
                     }
                 }
             }
+#endif
 
             return isValid;
         }
@@ -173,6 +179,7 @@ namespace Crest
             }
         }
 
+#if CREST_MATH
         internal static void FixOceanWindSpeed(SerializedObject settingsObject)
         {
             if (OceanRenderer.Instance != null
@@ -184,9 +191,9 @@ namespace Crest
                 EditorUtility.SetDirty(OceanRenderer.Instance);
             }
         }
+#endif // CREST_MATH
     }
 
-#if UNITY_EDITOR
     [CustomEditor(typeof(SimSettingsAnimatedWaves), true), CanEditMultipleObjects]
     class SimSettingsAnimatedWavesEditor : SimSettingsBaseEditor
     {
@@ -202,6 +209,5 @@ namespace Crest
             base.OnInspectorGUI();
         }
     }
-#endif
-#endif
+#endif // UNITY_EDITOR
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -51,10 +51,10 @@ namespace Crest
         [Tooltip("The render texture format to use for the wave simulation. It should only be changed if you need more precision. See the documentation for information.")]
         public GraphicsFormat _renderTextureGraphicsFormat = GraphicsFormat.R16G16B16A16_SFloat;
 
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
         [Predicated("_collisionSource", true, (int)CollisionSources.BakedFFT), DecoratedField]
         public FFTBakedData _bakedFFTData;
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS
 
         public override void AddToSettingsHash(ref int settingsHash)
         {
@@ -88,11 +88,11 @@ namespace Crest
                         Debug.LogError("Crest: Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
                     }
                     break;
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
                 case CollisionSources.BakedFFT:
                     result = new CollProviderBakedFFT(_bakedFFTData);
                     break;
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS
             }
 
             if (result == null)
@@ -149,7 +149,7 @@ namespace Crest
             }
             else if (_collisionSource == CollisionSources.BakedFFT)
             {
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
                 if (_bakedFFTData != null)
                 {
                     if (!Mathf.Approximately(_bakedFFTData._parameters._windSpeed * 3.6f, ocean._globalWindSpeed))
@@ -163,7 +163,7 @@ namespace Crest
                         );
                     }
                 }
-#else // CREST_MATH
+#else // CREST_UNITY_MATHEMATICS
                 showMessage
                 (
                     "The <i>Unity Mathematics (com.unity.mathematics)</i> package is required for baked collisions.",
@@ -173,9 +173,9 @@ namespace Crest
                 );
 
                 isValid = false;
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS
 
-#if !CREST_BURST
+#if !CREST_UNITY_BURST
                 showMessage
                 (
                     "The <i>Unity Burst (com.unity.burst)</i> package will greatly improve performance.",
@@ -183,7 +183,7 @@ namespace Crest
                     ValidatedHelper.MessageType.Warning, this,
                     ValidatedHelper.FixAddMissingBurstPackage
                 );
-#endif // CREST_BURST
+#endif // CREST_UNITY_BURST
             }
 
             return isValid;
@@ -199,7 +199,7 @@ namespace Crest
             }
         }
 
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
         internal static void FixOceanWindSpeed(SerializedObject settingsObject)
         {
             if (OceanRenderer.Instance != null
@@ -211,7 +211,7 @@ namespace Crest
                 EditorUtility.SetDirty(OceanRenderer.Instance);
             }
         }
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS
     }
 
     [CustomEditor(typeof(SimSettingsAnimatedWaves), true), CanEditMultipleObjects]

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -114,6 +114,11 @@ namespace Crest
             PackageManagerHelpers.AddMissingPackage("com.unity.mathematics");
         }
 
+        public static void FixAddMissingBurstPackage(SerializedObject componentOrGameObject)
+        {
+            PackageManagerHelpers.AddMissingPackage("com.unity.burst");
+        }
+
         public static bool ValidateRenderer(GameObject gameObject, string shaderPrefix, ShowMessage showMessage)
         {
             var renderer = gameObject.GetComponent<Renderer>();

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -9,6 +9,7 @@
 
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Crest.EditorHelpers;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
@@ -106,6 +107,11 @@ namespace Crest
             var renderer = gameObject.GetComponent<MeshRenderer>();
             Undo.DestroyObjectImmediate(renderer);
             EditorUtility.SetDirty(gameObject);
+        }
+
+        public static void FixAddMissingMathPackage(SerializedObject componentOrGameObject)
+        {
+            PackageManagerHelpers.AddMissingPackage("com.unity.mathematics");
         }
 
         public static bool ValidateRenderer(GameObject gameObject, string shaderPrefix, ShowMessage showMessage)

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -265,11 +265,20 @@ namespace Crest
                         foreach (var message in messages)
                         {
                             EditorGUILayout.BeginHorizontal();
+
                             var fixDescription = message._fixDescription;
+                            var originalGUIEnabled = GUI.enabled;
+
                             if (message._action != null)
                             {
                                 fixDescription += " Click the fix/repair button on the right to fix.";
+
+                                if ((message._action == ValidatedHelper.FixAddMissingMathPackage || message._action == ValidatedHelper.FixAddMissingBurstPackage) && PackageManagerHelpers.IsBusy)
+                                {
+                                    GUI.enabled = false;
+                                }
                             }
+
                             EditorGUILayout.HelpBox($"{message._message} {fixDescription}", messageType);
 
                             // Jump to object button.
@@ -324,6 +333,8 @@ namespace Crest
                                     }
                                 }
                             }
+
+                            GUI.enabled = originalGUIEnabled;
 
                             EditorGUILayout.EndHorizontal();
                         }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBakedData.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBakedData.cs
@@ -17,6 +17,8 @@
 // - We could potentially avoid starting a job for less than ~10 or so queries, assuming we can run the query
 //   code directly and still be Burst compiled.
 
+#if CREST_MATH
+
 using System;
 using System.Runtime.CompilerServices;
 using Unity.Collections;
@@ -327,3 +329,5 @@ namespace Crest
     }
 #endif // UNITY_EDITOR
 }
+
+#endif // CREST_MATH

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBakedData.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBakedData.cs
@@ -17,7 +17,7 @@
 // - We could potentially avoid starting a job for less than ~10 or so queries, assuming we can run the query
 //   code directly and still be Burst compiled.
 
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
 
 using System;
 using System.Runtime.CompilerServices;
@@ -330,4 +330,4 @@ namespace Crest
 #endif // UNITY_EDITOR
 }
 
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs
@@ -5,6 +5,7 @@
 //#define CREST_DEBUG_DUMP_EXRS
 
 #if UNITY_EDITOR
+#if CREST_MATH
 
 using System.Linq;
 using Unity.Mathematics;
@@ -189,4 +190,5 @@ namespace Crest
     }
 }
 
-#endif
+#endif // CREST_MATH
+#endif // UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs
@@ -5,7 +5,7 @@
 //#define CREST_DEBUG_DUMP_EXRS
 
 #if UNITY_EDITOR
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
 
 using System.Linq;
 using Unity.Mathematics;
@@ -190,5 +190,5 @@ namespace Crest
     }
 }
 
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS
 #endif // UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -403,6 +403,7 @@ namespace Crest
     [CustomEditor(typeof(ShapeFFT))]
     public class ShapeFFTEditor : ValidatedEditor
     {
+#if CREST_MATH
         /// <summary>
         /// Display some validation and statistics about the bake.
         /// </summary>
@@ -506,6 +507,7 @@ namespace Crest
                 GUI.enabled = true;
             }
         }
+#endif // CREST_MATH
     }
 #endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -395,6 +395,19 @@ namespace Crest
                 );
             }
 
+#if !CREST_MATH
+            if (_enableBakedCollision)
+            {
+                showMessage
+                (
+                    "The <i>Unity Mathematics (com.unity.mathematics)</i> package is required for baking.",
+                    "Add the <i>Unity Mathematics</i> package.",
+                    ValidatedHelper.MessageType.Warning, this,
+                    ValidatedHelper.FixAddMissingMathPackage
+                );
+            }
+#endif
+
             return isValid;
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -395,7 +395,7 @@ namespace Crest
                 );
             }
 
-#if !CREST_MATH
+#if !CREST_UNITY_MATHEMATICS
             if (_enableBakedCollision)
             {
                 showMessage
@@ -416,7 +416,7 @@ namespace Crest
     [CustomEditor(typeof(ShapeFFT))]
     public class ShapeFFTEditor : ValidatedEditor
     {
-#if CREST_MATH
+#if CREST_UNITY_MATHEMATICS
         /// <summary>
         /// Display some validation and statistics about the bake.
         /// </summary>
@@ -520,7 +520,7 @@ namespace Crest
                 GUI.enabled = true;
             }
         }
-#endif // CREST_MATH
+#endif // CREST_UNITY_MATHEMATICS
     }
 #endif
 }


### PR DESCRIPTION
Wraps burst attributes in defines as suggested by @kpietraszko. If the burst package is missing, it compiles but baking crashes Unity.

Also wraps baking classes with defines and wherever they are used. This seems like the simplest approach. I don't think wrapping a serialised property is really that much of an issue for this use case now that I think about it as losing the reference would be an edge case as it would require a user to remove the package and then serialise the reference holder.

Lastly, adds validation and fix functions to add missing packages.

ping @huwb in case you don't get a notification.